### PR TITLE
キーボードショートカットに対応しました

### DIFF
--- a/js/background.js
+++ b/js/background.js
@@ -1,25 +1,27 @@
-function execPreprocessingCopy(info){
-	const selectiontext=info.selectionText.toString();
-	execCopy(selectiontext);
+function execPreprocessingCopy(info) {
+  const selectiontext = info.selectionText.toString();
+  execCopy(selectiontext);
 }
 
 function openDeepL(info) {
-	const selectiontext = info.selectionText.toString();
-	window.open('https://www.deepl.com/translator#auto/ja/' + encodeURI(selectiontext));
+  const selectiontext = info.selectionText.toString();
+  window.open('https://www.deepl.com/translator#auto/ja/' + encodeURI(selectiontext));
 }
 
 chrome.contextMenus.create({
-	'title': '翻訳前処理をしてコピー',
-	'type': 'normal',
-	'contexts': ['selection'],
-	'onclick': execPreprocessingCopy,
+  'id': 'copy',
+  'title': '翻訳前処理をしてコピー',
+  'type': 'normal',
+  'contexts': ['selection'],
+  'onclick': execPreprocessingCopy,
 });
 
 chrome.contextMenus.create({
-	'title': '翻訳前処理をしてDeepL翻訳',
-	'type': 'normal',
-	'contexts': ['selection'],
-	'onclick': openDeepL,
+  'id': 'translate',
+  'title': '翻訳前処理をしてDeepL翻訳',
+  'type': 'normal',
+  'contexts': ['selection'],
+  'onclick': openDeepL,
 });
 
 console.log('Background activate');

--- a/js/background.js
+++ b/js/background.js
@@ -25,3 +25,30 @@ chrome.contextMenus.create({
 });
 
 console.log('Background activate');
+
+function copySelection(tab) {
+  chrome.tabs.executeScript(tab.id, {
+    code: "window.getSelection().toString();"
+  }, function (results) {
+    if (results.length > 0) {
+      execCopy(results[0]);
+    }
+  });
+}
+
+function getCurrentTab(callback) {
+  let queryOptions = { active: true, lastFocusedWindow: true };
+  chrome.tabs.query(queryOptions, ([tab]) => {
+    if (chrome.runtime.lastError)
+      console.error(chrome.runtime.lastError);
+    callback(tab);
+  });
+}
+
+chrome.commands.onCommand.addListener((command) => {
+  switch (command) {
+    case 'copy':
+      getCurrentTab(copySelection);
+      break;
+  }
+});

--- a/manifest.json
+++ b/manifest.json
@@ -3,19 +3,47 @@
   "description": "pdfのテキストを改行、ハイフンの削除などの前処理を行った状態でクリップボードにコピーできるようになります",
   "version": "1.0",
   "background": {
-    "scripts": [ "js/background.js","js/execCopy.js"]
+    "scripts": [
+      "js/background.js",
+      "js/execCopy.js"
+    ]
   },
   "content_scripts": [
     {
-      "matches": [ "<all_urls>" ],
-      "js": [ "js/content.js" ]
+      "matches": [
+        "<all_urls>"
+      ],
+      "js": [
+        "js/content.js"
+      ]
     }
   ],
-  "permissions": [ "contextMenus", "<all_urls>", "activeTab" ],
+  "permissions": [
+    "contextMenus",
+    "<all_urls>",
+    "activeTab"
+  ],
   "icons": {
     "16": "icon/icon16.png",
     "48": "icon/icon48.png",
     "128": "icon/icon128.png"
+  },
+  "commands": {
+    "copy": {
+      "suggested_key": {
+        "default": "Ctrl+Shift+C",
+        "mac": "Command+Shift+C"
+      },
+      "description": "余分なものを削除してコピー"
+    },
+    "_execute_action": {
+      "suggested_key": {
+        "windows": "Ctrl+Shift+C",
+        "mac": "Command+Shift+C",
+        "chromeos": "Ctrl+Shift+C",
+        "linux": "Ctrl+Shift+C"
+      }
+    }
   },
   "manifest_version": 2
 }


### PR DESCRIPTION
とてもお世話になっている拡張ですがキーボードショートカットが欲しかったので，キーボードショートカット対応に対応しました.
windowsだとctrl+shift+c, macだとcommand+shift+cでできます
キーバインドがうまく行っていない場合は拡張機能の設定のキーボードショートカットの設定から変更してみてください．
#4 